### PR TITLE
Add gzip compression

### DIFF
--- a/src/sentry_transport.c
+++ b/src/sentry_transport.c
@@ -275,7 +275,7 @@ sentry_gzipped_with_compression(const char *body, const size_t body_len,
     int err = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED,
         MAX_WBITS + 16, 9, Z_DEFAULT_STRATEGY);
     if (err != Z_OK) {
-        SENTRY_TRACEF("deflateInit2 failed: %d\n", err);
+        SENTRY_TRACEF("deflateInit2 failed: %d", err);
         return false;
     }
 
@@ -293,7 +293,7 @@ sentry_gzipped_with_compression(const char *body, const size_t body_len,
     }
 
     if (err != Z_STREAM_END) {
-        SENTRY_TRACEF("deflate failed: %d\n", err);
+        SENTRY_TRACEF("deflate failed: %d", err);
         sentry_free(buffer);
         buffer = NULL;
         deflateEnd(&stream);
@@ -304,6 +304,5 @@ sentry_gzipped_with_compression(const char *body, const size_t body_len,
     *compressed_body = buffer;
 
     deflateEnd(&stream);
-
     return true;
 }

--- a/src/sentry_transport.h
+++ b/src/sentry_transport.h
@@ -73,7 +73,6 @@ typedef struct sentry_prepared_http_request_s {
     char *body;
     size_t body_len;
     bool body_owned;
-    bool compressed;
 } sentry_prepared_http_request_t;
 
 /**

--- a/src/sentry_transport.h
+++ b/src/sentry_transport.h
@@ -73,6 +73,7 @@ typedef struct sentry_prepared_http_request_s {
     char *body;
     size_t body_len;
     bool body_owned;
+    bool compressed;
 } sentry_prepared_http_request_t;
 
 /**
@@ -88,5 +89,11 @@ sentry_prepared_http_request_t *sentry__prepare_http_request(
  * Free a previously allocated HTTP request.
  */
 void sentry__prepared_http_request_free(sentry_prepared_http_request_t *req);
+
+/**
+ * Gzip
+ */
+void sentry_gzipped_with_compression(const char *body, const size_t body_len,
+    char **compressed_body, size_t *compressed_body_len, bool *compressed);
 
 #endif

--- a/src/sentry_transport.h
+++ b/src/sentry_transport.h
@@ -92,7 +92,7 @@ void sentry__prepared_http_request_free(sentry_prepared_http_request_t *req);
 /**
  * Gzip
  */
-void sentry_gzipped_with_compression(const char *body, const size_t body_len,
-    char **compressed_body, size_t *compressed_body_len, bool *compressed);
+bool sentry_gzipped_with_compression(const char *body, const size_t body_len,
+    char **compressed_body, size_t *compressed_body_len);
 
 #endif


### PR DESCRIPTION
【sentry 上报时使用 gzip 压缩数据】
https://www.tapd.cn/35612194/prong/stories/view/1135612194004154269

参考：https://github.com/getsentry/sentry-cocoa/blob/3297d6e29cd37151f68e9c605aea8b44e5e432cb/Sources/Sentry/NSData%2BSentryCompression.m#L13

未压缩：
![image](https://github.com/MiaoSiLa/sentry-native/assets/50010647/c523178a-b586-499c-a926-1c6957df2739)

压缩后：
![image](https://github.com/MiaoSiLa/sentry-native/assets/50010647/a08987c1-cb60-4828-a238-0deaf44fa761)
